### PR TITLE
feat: Add content migration system for Dev-to-Prod sync (Vibe Kanban)

### DIFF
--- a/src/api/app.py
+++ b/src/api/app.py
@@ -8,7 +8,7 @@ All operations are logged comprehensively for monitoring and debugging.
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
-from src.api.routes import quiz_router, interview_prep_router, session_router, aptitude_router
+from src.api.routes import quiz_router, interview_prep_router, session_router, aptitude_router, migration_router
 from src.api.middleware import RequestLoggingMiddleware
 from src.api.logging_config import setup_api_logging
 from src.core.env import get_env_manager
@@ -55,6 +55,7 @@ def create_app() -> FastAPI:
     app.include_router(interview_prep_router, prefix="/api/v1")
     app.include_router(session_router, prefix="/api/v1")
     app.include_router(aptitude_router, prefix="/api/v1")
+    app.include_router(migration_router)
     
     # Root API endpoint 
     @app.get("/api/v1")
@@ -87,6 +88,14 @@ def create_app() -> FastAPI:
                     "upload_study_guide": "POST /api/v1/aptitude/upload-study-guide",
                     "topics": "GET /api/v1/aptitude/topics",
                     "upload": "POST /api/v1/aptitude/upload"
+                },
+                "migration": {
+                    "migrate": "POST /api/v1/migration/migrate",
+                    "export": "POST /api/v1/migration/export",
+                    "sync": "POST /api/v1/migration/sync",
+                    "list_exports": "GET /api/v1/migration/exports",
+                    "get_export": "GET /api/v1/migration/exports/{filename}",
+                    "status": "GET /api/v1/migration/status"
                 }
             },
             "docs": "/docs"

--- a/src/api/controllers/migration_controller.py
+++ b/src/api/controllers/migration_controller.py
@@ -1,0 +1,355 @@
+"""Migration controller — orchestrates content export and sync between environments."""
+
+import json
+import logging
+import os
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+import requests
+
+from src.core.config import config
+
+logger = logging.getLogger(__name__)
+
+
+class MigrationController:
+    def __init__(self):
+        self.output_dir = os.path.join(config.output_dir, "migrations")
+        os.makedirs(self.output_dir, exist_ok=True)
+
+    def _get_api_url(self, env: str) -> str:
+        if env == "local":
+            return config.local_api_base_url
+        elif env == "prod":
+            return config.prod_api_base_url
+        return config.dev_api_base_url
+
+    def _get_admin_secret(self, provided: Optional[str] = None) -> str:
+        return provided or os.environ.get("TBE_ADMIN_SECRET", "TBEAdmin")
+
+    # ─── Export ───────────────────────────────────────────────────────────
+
+    def export_content(
+        self,
+        env: str,
+        content_types: List[str],
+        filters: Optional[Dict[str, Any]] = None,
+        admin_secret: Optional[str] = None,
+        save_to_file: bool = True,
+    ) -> Dict[str, Any]:
+        """Export content from an environment via the export API."""
+        base_url = self._get_api_url(env)
+        secret = self._get_admin_secret(admin_secret)
+        url = f"{base_url}/api/v1/content/export"
+
+        all_exported: Dict[str, Any] = {}
+        errors = []
+
+        for ct in content_types:
+            export_type = "all" if ct == "all" else ct
+
+            params: Dict[str, str] = {"type": export_type}
+            if filters:
+                if filters.get("topics"):
+                    params["topics"] = ",".join(filters["topics"])
+                if filters.get("slugs"):
+                    params["slugs"] = ",".join(filters["slugs"])
+                if filters.get("roadmap"):
+                    params["roadmap"] = filters["roadmap"]
+                if filters.get("domain"):
+                    params["domain"] = ",".join(filters["domain"])
+                if filters.get("difficulty"):
+                    params["difficulty"] = ",".join(filters["difficulty"])
+                if filters.get("categoryNames"):
+                    params["categoryNames"] = ",".join(filters["categoryNames"])
+
+            try:
+                response = requests.get(
+                    url,
+                    params=params,
+                    headers={"x-admin-secret": secret},
+                    timeout=60,
+                )
+                response.raise_for_status()
+                resp_data = response.json()
+
+                if resp_data.get("status"):
+                    exported = resp_data.get("data", {})
+                    all_exported[ct] = exported
+
+                    if save_to_file:
+                        self._save_export(env, ct, exported)
+                else:
+                    errors.append(
+                        f"{ct}: {resp_data.get('message', 'Unknown error')}"
+                    )
+
+            except requests.Timeout:
+                errors.append(f"{ct}: Request timed out")
+            except requests.ConnectionError:
+                errors.append(f"{ct}: Could not connect to {base_url}")
+            except requests.HTTPError as e:
+                errors.append(f"{ct}: HTTP {e.response.status_code}")
+            except Exception as e:
+                errors.append(f"{ct}: {str(e)}")
+
+        summary = self._build_export_summary(all_exported)
+
+        return {
+            "ok": len(errors) == 0,
+            "source": env,
+            "sourceUrl": base_url,
+            "exported": summary,
+            "rawData": all_exported,
+            "errors": errors if errors else None,
+        }
+
+    def _save_export(self, env: str, content_type: str, data: Dict) -> str:
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        filename = f"export_{env}_{content_type}_{timestamp}.json"
+        filepath = os.path.join(self.output_dir, filename)
+
+        with open(filepath, "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2, default=str)
+
+        logger.info("Saved export to %s", filepath)
+        return filepath
+
+    def _build_export_summary(self, results: Dict) -> Dict:
+        summary = {}
+        for ct, data in results.items():
+            if not isinstance(data, dict):
+                continue
+            for key in ("dsaQuestions", "interviewSheets", "aptitude", "quizzes"):
+                nested = data.get(key)
+                if nested and isinstance(nested, dict) and "count" in nested:
+                    summary[key] = nested["count"]
+        return summary
+
+    # ─── Sync ─────────────────────────────────────────────────────────────
+
+    def sync_content(
+        self,
+        env: str,
+        content_type: str,
+        data: Dict[str, Any],
+        dry_run: bool = True,
+        admin_secret: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Sync content to a target environment via the sync API."""
+        base_url = self._get_api_url(env)
+        secret = self._get_admin_secret(admin_secret)
+        url = f"{base_url}/api/v1/content/sync"
+
+        payload = {
+            "type": content_type,
+            "dryRun": dry_run,
+            "data": data,
+        }
+
+        try:
+            response = requests.post(
+                url,
+                json=payload,
+                headers={
+                    "x-admin-secret": secret,
+                    "Content-Type": "application/json",
+                },
+                timeout=120,
+            )
+            response.raise_for_status()
+            resp_data = response.json()
+
+            return {
+                "ok": resp_data.get("status", False),
+                "target": env,
+                "targetUrl": base_url,
+                "dryRun": dry_run,
+                "contentType": content_type,
+                "result": resp_data.get("data"),
+                "message": resp_data.get("message", ""),
+            }
+
+        except requests.Timeout:
+            return {"ok": False, "message": f"Sync timed out for {content_type}"}
+        except requests.ConnectionError:
+            return {"ok": False, "message": f"Could not connect to {base_url}"}
+        except requests.HTTPError as e:
+            return {
+                "ok": False,
+                "message": f"HTTP {e.response.status_code}: {e.response.text[:300]}",
+            }
+        except Exception as e:
+            return {"ok": False, "message": f"Sync failed: {str(e)}"}
+
+    # ─── Full Migration ───────────────────────────────────────────────────
+
+    def migrate(
+        self,
+        source_env: str,
+        target_env: str,
+        content_types: List[str],
+        dry_run: bool = True,
+        filters: Optional[Dict[str, Any]] = None,
+        source_admin_secret: Optional[str] = None,
+        target_admin_secret: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Full migration: export from source, sync to target."""
+        if source_env == target_env:
+            return {
+                "ok": False,
+                "message": "Source and target cannot be the same environment",
+            }
+
+        logger.info(
+            "Starting migration: %s -> %s (types=%s, dry_run=%s)",
+            source_env,
+            target_env,
+            content_types,
+            dry_run,
+        )
+
+        # Phase 1: Export
+        export_result = self.export_content(
+            env=source_env,
+            content_types=content_types,
+            filters=filters,
+            admin_secret=source_admin_secret,
+            save_to_file=True,
+        )
+
+        if not export_result.get("ok"):
+            return {
+                "ok": False,
+                "message": "Export phase failed",
+                "phase": "export",
+                "details": export_result,
+            }
+
+        raw_data = export_result.get("rawData", {})
+
+        # Phase 2: Sync each content type
+        sync_results = {}
+        sync_errors = []
+
+        type_data_map = self._prepare_sync_payloads(content_types, raw_data)
+
+        for sync_type, sync_data in type_data_map.items():
+            if not sync_data:
+                continue
+
+            result = self.sync_content(
+                env=target_env,
+                content_type=sync_type,
+                data=sync_data,
+                dry_run=dry_run,
+                admin_secret=target_admin_secret,
+            )
+            sync_results[sync_type] = result
+            if not result.get("ok"):
+                sync_errors.append(f"{sync_type}: {result.get('message')}")
+
+        return {
+            "ok": len(sync_errors) == 0,
+            "source": source_env,
+            "target": target_env,
+            "dryRun": dry_run,
+            "export": export_result.get("exported"),
+            "sync": sync_results,
+            "errors": sync_errors if sync_errors else None,
+            "message": (
+                "Dry run complete — no changes made"
+                if dry_run
+                else f"Migration {'completed' if not sync_errors else 'completed with errors'}"
+            ),
+        }
+
+    def _prepare_sync_payloads(
+        self, content_types: List[str], raw_data: Dict
+    ) -> Dict[str, Dict]:
+        """Convert exported raw data into per-type sync payloads."""
+        result = {}
+
+        def extract(data: Dict, key: str, inner: str):
+            nested = data.get(key, {})
+            if isinstance(nested, dict):
+                return nested.get(inner, [])
+            return []
+
+        for ct in content_types:
+            if ct == "all":
+                for ct_key, raw in raw_data.items():
+                    if not isinstance(raw, dict):
+                        continue
+                    if "dsaQuestions" in raw:
+                        qs = extract(raw, "dsaQuestions", "questions")
+                        if qs:
+                            result["dsa-questions"] = {"questions": qs}
+                    if "interviewSheets" in raw:
+                        ss = extract(raw, "interviewSheets", "sheets")
+                        if ss:
+                            result["interview-sheets"] = {"sheets": ss}
+                    if "aptitude" in raw:
+                        ts = extract(raw, "aptitude", "topics")
+                        if ts:
+                            result["aptitude"] = {"topics": ts}
+                    if "quizzes" in raw:
+                        qz = extract(raw, "quizzes", "quizzes")
+                        if qz:
+                            result["quizzes"] = {"quizzes": qz}
+                break
+            else:
+                raw = raw_data.get(ct, {})
+                if not isinstance(raw, dict):
+                    continue
+                if ct == "dsa-questions":
+                    qs = extract(raw, "dsaQuestions", "questions")
+                    if qs:
+                        result[ct] = {"questions": qs}
+                elif ct == "interview-sheets":
+                    ss = extract(raw, "interviewSheets", "sheets")
+                    if ss:
+                        result[ct] = {"sheets": ss}
+                elif ct == "aptitude":
+                    ts = extract(raw, "aptitude", "topics")
+                    if ts:
+                        result[ct] = {"topics": ts}
+                elif ct == "quizzes":
+                    qz = extract(raw, "quizzes", "quizzes")
+                    if qz:
+                        result[ct] = {"quizzes": qz}
+
+        return result
+
+    # ─── List Exports ─────────────────────────────────────────────────────
+
+    def list_exports(self) -> List[Dict[str, Any]]:
+        exports = []
+        if not os.path.exists(self.output_dir):
+            return exports
+
+        for filename in sorted(os.listdir(self.output_dir), reverse=True):
+            if filename.startswith("export_") and filename.endswith(".json"):
+                filepath = os.path.join(self.output_dir, filename)
+                stat = os.stat(filepath)
+                parts = filename.replace("export_", "").replace(".json", "").split("_")
+
+                exports.append({
+                    "filename": filename,
+                    "filepath": filepath,
+                    "env": parts[0] if parts else "unknown",
+                    "contentType": parts[1] if len(parts) > 1 else "unknown",
+                    "sizeBytes": stat.st_size,
+                    "createdAt": datetime.fromtimestamp(stat.st_ctime).isoformat(),
+                })
+
+        return exports
+
+    def load_export_file(self, filename: str) -> Dict[str, Any]:
+        filepath = os.path.join(self.output_dir, filename)
+        if not os.path.exists(filepath):
+            raise FileNotFoundError(f"Export file not found: {filename}")
+
+        with open(filepath, "r", encoding="utf-8") as f:
+            return json.load(f)

--- a/src/api/models/migration_models.py
+++ b/src/api/models/migration_models.py
@@ -1,0 +1,65 @@
+"""Pydantic models for content migration endpoints."""
+
+from enum import Enum
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, Field
+
+
+class ContentType(str, Enum):
+    DSA_QUESTIONS = "dsa-questions"
+    INTERVIEW_SHEETS = "interview-sheets"
+    APTITUDE = "aptitude"
+    QUIZZES = "quizzes"
+    ALL = "all"
+
+
+class MigrateRequest(BaseModel):
+    content_types: List[ContentType] = Field(
+        default=[ContentType.ALL],
+        description="Which content types to migrate",
+    )
+    dry_run: bool = Field(
+        default=True,
+        description="If true, shows what would change without making changes",
+    )
+    source_env: str = Field(
+        default="dev",
+        description="Source environment to export from (dev | prod | local)",
+    )
+    target_env: str = Field(
+        default="prod",
+        description="Target environment to sync to (dev | prod | local)",
+    )
+    filters: Optional[Dict[str, Any]] = Field(
+        default=None,
+        description="Optional filters: topics, slugs, domain, difficulty, categoryNames",
+    )
+    source_admin_secret: Optional[str] = None
+    target_admin_secret: Optional[str] = None
+
+
+class MigrationStatus(BaseModel):
+    ok: bool
+    message: str
+    dry_run: bool = False
+    source: str = ""
+    target: str = ""
+    results: Optional[Dict[str, Any]] = None
+    errors: Optional[List[str]] = None
+
+
+class ExportRequest(BaseModel):
+    env: str = Field(default="dev", description="Environment to export from")
+    content_types: List[ContentType] = Field(default=[ContentType.ALL])
+    filters: Optional[Dict[str, Any]] = None
+    admin_secret: Optional[str] = None
+    save_to_file: bool = Field(default=True)
+
+
+class SyncRequest(BaseModel):
+    env: str = Field(default="prod", description="Environment to sync to")
+    content_type: ContentType
+    data: Dict[str, Any] = Field(description="Content data to sync")
+    dry_run: bool = True
+    admin_secret: Optional[str] = None

--- a/src/api/routes/__init__.py
+++ b/src/api/routes/__init__.py
@@ -8,11 +8,13 @@ from src.api.routes.quiz import router as quiz_router
 from src.api.routes.interview_prep import router as interview_prep_router
 from src.api.routes.session import router as session_router
 from src.api.routes.aptitude import router as aptitude_router
+from src.api.routes.migration import router as migration_router
 
 __all__ = [
     "quiz_router",
     "interview_prep_router",
     "session_router",
     "aptitude_router",
+    "migration_router",
 ]
 

--- a/src/api/routes/migration.py
+++ b/src/api/routes/migration.py
@@ -1,0 +1,133 @@
+"""Content migration routes — export from dev, sync to prod."""
+
+import logging
+
+from fastapi import APIRouter, HTTPException
+
+from src.api.controllers.migration_controller import MigrationController
+from src.api.models.migration_models import (
+    ExportRequest,
+    MigrateRequest,
+    MigrationStatus,
+    SyncRequest,
+)
+
+logger = logging.getLogger(__name__)
+router = APIRouter(prefix="/api/v1/migration", tags=["Content Migration"])
+controller = MigrationController()
+
+
+@router.post("/migrate", response_model=MigrationStatus)
+def migrate_content(payload: MigrateRequest):
+    """
+    Full migration: export content from source environment and sync to target.
+
+    Default: dry_run=True (preview only). Set dry_run=False to execute.
+    Default: source=dev, target=prod.
+    """
+    try:
+        content_types = [ct.value for ct in payload.content_types]
+
+        result = controller.migrate(
+            source_env=payload.source_env,
+            target_env=payload.target_env,
+            content_types=content_types,
+            dry_run=payload.dry_run,
+            filters=payload.filters,
+            source_admin_secret=payload.source_admin_secret,
+            target_admin_secret=payload.target_admin_secret,
+        )
+
+        return MigrationStatus(
+            ok=result.get("ok", False),
+            message=result.get("message", ""),
+            dry_run=payload.dry_run,
+            source=payload.source_env,
+            target=payload.target_env,
+            results=result,
+        )
+    except Exception as e:
+        logger.error("Migration failed: %s", e, exc_info=True)
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.post("/export")
+def export_content(payload: ExportRequest):
+    """Export content from an environment and save to JSON files."""
+    try:
+        content_types = [ct.value for ct in payload.content_types]
+
+        result = controller.export_content(
+            env=payload.env,
+            content_types=content_types,
+            filters=payload.filters,
+            admin_secret=payload.admin_secret,
+            save_to_file=payload.save_to_file,
+        )
+
+        return result
+    except Exception as e:
+        logger.error("Export failed: %s", e, exc_info=True)
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.post("/sync")
+def sync_content(payload: SyncRequest):
+    """
+    Sync content to a target environment.
+
+    Reads from provided payload data.
+    Default: dry_run=True (preview only).
+    """
+    try:
+        result = controller.sync_content(
+            env=payload.env,
+            content_type=payload.content_type.value,
+            data=payload.data,
+            dry_run=payload.dry_run,
+            admin_secret=payload.admin_secret,
+        )
+
+        return result
+    except Exception as e:
+        logger.error("Sync failed: %s", e, exc_info=True)
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.get("/exports")
+def list_exports():
+    """List all previously saved export files."""
+    return {"exports": controller.list_exports()}
+
+
+@router.get("/exports/{filename}")
+def get_export(filename: str):
+    """Load and return a previously saved export file."""
+    try:
+        data = controller.load_export_file(filename)
+        return {"ok": True, "filename": filename, "data": data}
+    except FileNotFoundError:
+        raise HTTPException(
+            status_code=404, detail=f"Export file not found: {filename}"
+        )
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.get("/status")
+def migration_status():
+    """Health check and configuration info for the migration system."""
+    from src.core.config import config as app_config
+
+    return {
+        "ok": True,
+        "environment": app_config.environment,
+        "endpoints": {
+            "local": app_config.local_api_base_url,
+            "dev": app_config.dev_api_base_url,
+            "prod": app_config.prod_api_base_url,
+        },
+        "activeApiUrl": app_config.api_base_url,
+        "exportDir": controller.output_dir,
+        "exportCount": len(controller.list_exports()),
+    }


### PR DESCRIPTION
## Summary

Adds a complete content migration module to The-Boring-Agents that enables safe, repeatable migration of content (DSA questions, interview sheets, aptitude topics, quizzes) from Dev to Prod environments via the TBE-Web API.

### Problem

Content is created and tested on the Dev environment, but there was no mechanism to migrate it to Prod. Manual processes were error-prone, and pushing the same content twice could cause duplicates or data loss. This affected all products — DSA Yatra, On Campus (DSA + Aptitude + Quiz), and Interview Prep.

### What Changed

**New files:**

| File | Purpose |
|---|---|
| `src/api/models/migration_models.py` | Pydantic models — `MigrateRequest`, `ExportRequest`, `SyncRequest`, `ContentType` enum with support for DSA questions, interview sheets, aptitude, and quizzes |
| `src/api/controllers/migration_controller.py` | Core orchestration — exports content from source env via API, saves to JSON files, syncs to target env. Supports dry-run, filters, and incremental migration |
| `src/api/routes/migration.py` | 6 REST endpoints under `/api/v1/migration/` — migrate, export, sync, list exports, get export, status |

**Modified files:**

| File | Change |
|---|---|
| `src/api/routes/__init__.py` | Added `migration_router` to exports |
| `src/api/app.py` | Registered migration router, added migration endpoints to API docs |

### API Endpoints

| Method | Endpoint | Purpose |
|---|---|---|
| `POST` | `/api/v1/migration/migrate` | Full migration: export from source → sync to target (dry-run by default) |
| `POST` | `/api/v1/migration/export` | Export content from an environment to JSON files |
| `POST` | `/api/v1/migration/sync` | Sync content to a target environment |
| `GET` | `/api/v1/migration/exports` | List previously saved export files |
| `GET` | `/api/v1/migration/exports/{filename}` | Load a specific export file |
| `GET` | `/api/v1/migration/status` | Health check and env configuration info |

### How It Works

```
Dev MongoDB → [Export via TBE-Web API] → JSON files → [Sync via TBE-Web API] → Prod MongoDB
```

The migration controller calls the TBE-Web content export/sync endpoints (companion PR needed in TBE-Web). All sync operations are **merge-based** — existing items are updated by natural key (title, slug, categoryName, topic), new items are added, nothing is ever deleted, and `_id`s are preserved.

### Usage

```bash
# Dry run (safe, no changes made)
curl -X POST http://localhost:8000/api/v1/migration/migrate \
  -H "Content-Type: application/json" \
  -d '{"source_env": "dev", "target_env": "prod", "content_types": ["all"], "dry_run": true}'

# Execute for specific content type with filters
curl -X POST http://localhost:8000/api/v1/migration/migrate \
  -H "Content-Type: application/json" \
  -d '{"source_env": "dev", "target_env": "prod", "content_types": ["dsa-questions"], "dry_run": false, "filters": {"topics": ["ARRAY", "STRING"]}}'
```

### Safety Guarantees

- **Dry-run by default** — `dry_run: true` is the default; must explicitly set `false` to execute
- **Merge-only** — adds new content, updates existing, never deletes
- **`_id` preservation** — existing document IDs are never regenerated (critical for `UserSheet` and `InterviewSheet` references)
- **Admin-secret protected** — all TBE-Web export/sync endpoints require `x-admin-secret`
- **Export audit trail** — every export is saved to `./output/migrations/` as timestamped JSON

### Companion Changes (TBE-Web — separate PR)

This PR depends on new endpoints being added to TBE-Web:
- `GET /api/v1/content/export` — admin-only content export
- `POST /api/v1/content/sync` — admin-only merge-based content import
- Bug fix: DSA question `content` vs `answer` field mismatch (4 files)
- Bug fix: Aptitude bulk upload `$set` replaced all questions instead of merging (2 files)

---

This PR was written using [Vibe Kanban](https://vibekanban.com)